### PR TITLE
docs: add GitHub Actions CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/HenryOnMic/demo_be_auto/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/HenryOnMic/demo_be_auto/actions/workflows/ci.yml)
+
 # FastAPI + MongoDB CRUD Backend
 
 A full-featured backend with FastAPI, MongoDB, Docker, TDD, Swagger UI, and GitHub MCP automation.


### PR DESCRIPTION
This PR adds a CI status badge to the top of the README for visibility of build/test status on the main branch.

- Adds badge for `.github/workflows/ci.yml`
- Keeps documentation up to date

@HenryOnMic Automated PR per .cursorrules item 10.